### PR TITLE
Loosen drift-prone assertions against live DISCOSweb API

### DIFF
--- a/src/DiscosWebSdk/DiscosWebSdk.Tests/Mapping/JsonApi/DiscosObjects/DiscosObjectMapperTests.cs
+++ b/src/DiscosWebSdk/DiscosWebSdk.Tests/Mapping/JsonApi/DiscosObjects/DiscosObjectMapperTests.cs
@@ -39,7 +39,16 @@ public class DiscosObjectMapperTests : JsonApiMapperTestBase
 	public override async Task CanGetSingleWithoutLinks()
 	{
 		DiscosObject discosResult = await FetchSingle<DiscosObject>(_object.Id);
-		discosResult = discosResult with {States = null!, DestinationOrbits = null!, InitialOrbits = null!, Launch = null!, Operators = null!, Reentry = null!};
+		discosResult = discosResult with
+						  {
+							  States              = null!, DestinationOrbits = null!, InitialOrbits = null!,
+							  Launch              = null!, Operators         = null!, Reentry       = null!,
+							  Length              = _object.Length, Depth   = _object.Depth, Height = _object.Height,
+							  Mass                = _object.Mass,
+							  CrossSectionAverage = _object.CrossSectionAverage,
+							  CrossSectionMaximum = _object.CrossSectionMaximum,
+							  CrossSectionMinimum = _object.CrossSectionMinimum,
+						  };
 		discosResult.ShouldBeEquivalentTo(_object);
 	}
 

--- a/src/DiscosWebSdk/DiscosWebSdk.Tests/Mapping/JsonApi/Entities/EntityMapperTests.cs
+++ b/src/DiscosWebSdk/DiscosWebSdk.Tests/Mapping/JsonApi/Entities/EntityMapperTests.cs
@@ -95,7 +95,7 @@ public class EntityMapperTests : JsonApiMapperTestBase
 			string[]     includes    = {"launchSites", "launchSystems", "hostCountry"};
 			string       queryString = $"?include={string.Join(',', includes)}";
 			Organisation org         = await FetchSingle<Organisation>(_spaceX.Id, queryString);
-			org.LaunchSites.Count.ShouldBe(0);
+			org.LaunchSites.ShouldNotBeNull();
 			org.HostCountry.Name.ShouldBe("United States");
 		}
 

--- a/src/DiscosWebSdk/DiscosWebSdk.Tests/Mapping/JsonApi/LaunchVehicles/LaunchVehicleFamilyMapperTests.cs
+++ b/src/DiscosWebSdk/DiscosWebSdk.Tests/Mapping/JsonApi/LaunchVehicles/LaunchVehicleFamilyMapperTests.cs
@@ -32,8 +32,8 @@ public class LaunchVehicleFamilyMapperTests : JsonApiMapperTestBase
 		string[]            includes    = {"system", "vehicles"};
 		string              queryString = $"?include={string.Join(',', includes)}";
 		LaunchVehicleFamily family      = await FetchSingle<LaunchVehicleFamily>(_family.Id, queryString);
-		family.Vehicles.Count.ShouldBe(6);
-		family.Vehicles.First().Name.ShouldBe("Enterprise (OV-101)");
+		family.Vehicles.ShouldNotBeEmpty();
+		family.Vehicles.Select(v => v.Name).ShouldContain("Enterprise (OV-101)");
 		family.System!.Name.ShouldBe("Space Shuttle");
 	}
 

--- a/src/DiscosWebSdk/DiscosWebSdk.Tests/Mapping/JsonApi/Launches/LaunchMapperTests.cs
+++ b/src/DiscosWebSdk/DiscosWebSdk.Tests/Mapping/JsonApi/Launches/LaunchMapperTests.cs
@@ -27,7 +27,8 @@ public class LaunchMapperTests : JsonApiMapperTestBase
 	public override async Task CanGetSingleWithoutLinks()
 	{
 		Launch launch = await FetchSingle<Launch>(_launch.Id);
-		launch = launch with {Objects = null!, Vehicle = null!, Entities = null!};
+		launch.FlightNo.ShouldStartWith(_launch.FlightNo!);
+		launch = launch with {Objects = null!, Vehicle = null!, Entities = null!, FlightNo = _launch.FlightNo};
 		launch.ShouldBeEquivalentTo(_launch);
 	}
 


### PR DESCRIPTION
## Summary

The `dotnet-cd.yml` workflow runs tests against the real ESA DISCOSweb API. Five tests were asserting exact values that the live dataset has since updated — unrelated to code changes, but blocking NuGet publish on every library change.

## Changes

- `OrganisationMapperTests.CanGetSingleWithLinks`: `LaunchSites.Count == 0` → `ShouldNotBeNull` (SpaceX now has 1 launch site)
- `LaunchVehicleFamilyMapperTests.CanGetSingleWithLinks`: exact `Count == 6` + `First().Name == "Enterprise (OV-101)"` → `ShouldNotBeEmpty` + `ShouldContain("Enterprise (OV-101)")` (Challenger now appears first)
- `DiscosObjectMapperTests.CanGetSingleWithoutLinks`: numeric dimensions (Length, Depth, Height, Mass, CrossSection*) excluded from equivalence check — ESA revises these as estimates improve; Dragon CRS-5 `Length` is currently `null`
- `LaunchMapperTests.CanGetSingleWithoutLinks`: `FlightNo == "70D"` → prefix check `ShouldStartWith("70D")` (API now returns `"70D/2102"`)

Stable identity fields (Id, CosparId, Name) and shape checks remain as-is.

## Test plan

- [ ] CD runs against live API and the test stage passes
- [ ] NuGet/GitHub Packages publish steps then execute