### PR TITLE
Loosen Launch.Epoch exact-time assertion

### DIFF
--- a/src/DiscosWebSdk/DiscosWebSdk.Tests/Mapping/JsonApi/Launches/LaunchMapperTests.cs
+++ b/src/DiscosWebSdk/DiscosWebSdk.Tests/Mapping/JsonApi/Launches/LaunchMapperTests.cs
@@ -28,7 +28,8 @@ public class LaunchMapperTests : JsonApiMapperTestBase
 	{
 		Launch launch = await FetchSingle<Launch>(_launch.Id);
 		launch.FlightNo.ShouldStartWith(_launch.FlightNo!);
-		launch = launch with {Objects = null!, Vehicle = null!, Entities = null!, FlightNo = _launch.FlightNo};
+		launch.Epoch!.Value.Date.ShouldBe(_launch.Epoch!.Value.Date);
+		launch = launch with {Objects = null!, Vehicle = null!, Entities = null!, FlightNo = _launch.FlightNo, Epoch = _launch.Epoch};
 		launch.ShouldBeEquivalentTo(_launch);
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #218. The ESA dataset has refined Launch #1's `Epoch` from `1961-01-31T20:21:19` to `1961-01-31T20:24:00`. The date portion is stable, but the time is not.

## Change

`LaunchMapperTests.CanGetSingleWithoutLinks`: assert `Epoch.Date` matches, and exclude the full `Epoch` from the record-equivalence check.